### PR TITLE
🐞 fix: 更新api地址，支持断点续传，添加文档注释，修改部分代码逻辑。

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,85 +1,116 @@
-
+import os
+import pandas as pd
 import requests
-import csv
 
-headers = {
+# HTTP请求头
+HEADERS = {
     'Accept': 'application/json',
     'Content-Type': 'application/json;charset=utf-8',
     'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.5005.124 Safari/537.36 Edg/102.0.1245.44'
 }
 
+# 每页请求的项目数量
+PAGE_SIZE = 30
 
-def get_detail(year, sid):
-    lst = []
-    try:
-        for i in range(1, 11):
-            url = f"https://static-data.gaokao.cn/www/2.0/schoolspecialindex/{year}/{sid}/33/3/16/{i}.json"
-            data = requests.request(
-                "GET", url, headers=headers, timeout=0.1).json()['data']
-            num = int(data['numFound'])
-            lst += data['item']
-            if num <= i * 10:
-                break
-    except Exception:
-        print('Error:', url)
-    return lst
+
+def get_detail(year, school_id):
+    """
+    获取给定年份和学校ID的详细信息。
+
+    :param year: (int) 要获取数据的年份。
+    :param school_id: (str) 要获取数据的学校ID。
+
+    :return: (list) 包含详细信息的字典列表。
+    """
+    details = []
+    for i in range(1, 11):
+        url = f"https://api.zjzw.cn/web/api/?page=1&school_id={school_id}&size=20&uri=apidata/api/gk/score/special&year={year}"
+        response = requests.get(url, headers=HEADERS)
+        data = response.json()['data']
+        details += data['item']
+
+        majors_num = int(data['numFound'])
+        if majors_num <= i * 20:
+            break
+    return details
 
 
 def get_school_list(province_id="", is_985="", is_211="", is_dual_class=""):
-    '''
-        is_985 in (0, 1)
-        is_211 in (0, 1)
-        is_dual_class in (0, 1)
-    '''
-    page_size = 30
-    lst_sch = []
+    """
+    获取给定省份的学校列表。
+
+    :param province_id: (str) 要获取学校的省份ID。
+    :param is_985: (0, 1) 是否为985学校。
+    :param is_211: (0, 1) 是否为211学校。
+    :param is_dual_class: (0, 1) 是否为双一流学校。
+
+    :return: (list) 包含学校信息的列表。
+    """
+    schools = []
     for i in range(1, 200):
-        url = f"https://api.eol.cn/web/api/?admissions=&central=&department=&dual_class=&f211={is_211}&f985={is_985}&is_doublehigh=&keyword=&page={i}&ranktype=&request_type=1&school_type=6000&type=&uri=apidata/api/gk/school/lists&is_dual_class=&nature=36000&size={page_size}&province_id={province_id}"
-        response = requests.request("GET", url, headers=headers)
-        data = response.json()
-        num = int(data['data']['numFound'])
-        for item in data['data']['item']:
-            lst_sch.append([item['school_id'], str(item['code_enroll']), item['name'],
-                           item['province_name'], item['city_name'], item['address']])
+        url = (f"https://api.zjzw.cn/web/api/?keyword=&is_dual_class={is_dual_class}&f211={is_211}&f985={is_985}"
+               f"&page={i}&province_id={province_id}&school_type=&size={PAGE_SIZE}&uri=apidata/api/gkv3/school/lists")
+        response = requests.get(url, headers=HEADERS)
+        data = response.json()['data']
+        schools += [[item['school_id'], str(item['code_enroll']),
+                     item['name'], item['province_name'], item['city_name']]
+                    for item in data['item']]
 
-        if i * 30 >= num:
+        schools_num = int(data['data']['numFound'])
+        if i * PAGE_SIZE >= schools_num:
             break
-    return lst_sch
+    return schools
 
 
-def main():
-    save_file = open('./output/result.csv', 'w')
-    output = csv.writer(save_file)
-    output.writerow(['年份', '省份', '院校代码', '学校', '学科门类', '专业类',
-                    '专业名称', '最低分', '最低位次', '选科要求', '城市', '地址' '录取批次', '网址'])
-    lst_sch = get_school_list(province_id="33")
-    for sid, scode, sname, province, city, address in lst_sch:
-        print(sid, scode[:-2], sname, province, city, address)
-        for year in range(2021, 2016, -1):
-            data = get_detail(year=year, sid=sid)
-            for item in data:
-                if item['level2'] in ('4', '5'):    # 经济学, 法学
-                    tmp = [year, province, scode[:-2], sname, item['level2_name'], item['level3_name'], item['spname'], item['min'], item['min_section'],
-                           item['sp_info'], city, address, item['local_batch_name'], f'https://www.gaokao.cn/school/{sid}/provinceline']
-                    output.writerow(tmp)
+def get_progress():
+    """
+    获取数据抓取的当前进度和已抓取的数据。
 
-    save_file.close()
+    :return: (tuple) 包含当前进度(int)和已抓取的数据(DataFrame)的元组。
+    """
+    if os.path.exists('./progress.txt'):
+        with open('./progress.txt', 'r') as f:
+            return int(f.read()), pd.read_csv('./output/result.csv')
+    else:
+        return 0, pd.DataFrame(
+            columns=['年份', '省份', '院校代码', '学校', '专业名称', '最低分', '最低位次', '选科要求', '城市',
+                     '录取批次', '网址'])
 
 
-if __name__ == '__main__':
-    main()
+def save_progress(i, df):
+    """
+    保存数据抓取的当前进度和抓取的数据。
 
-'''
-    0: {name: "哲学", code: "01", spe_id: "3"}
-    1: {name: "经济学", code: "02", spe_id: "4"}
-    2: {name: "法学", code: "03", spe_id: "5"}
-    3: {name: "教育学", code: "04", spe_id: "6"}
-    4: {name: "文学", code: "05", spe_id: "7"}
-    5: {name: "历史学", code: "06", spe_id: "8"}
-    6: {name: "理学", code: "07", spe_id: "9"}
-    7: {name: "工学", code: "08", spe_id: "10"}
-    8: {name: "农学", code: "09", spe_id: "11"}
-    9: {name: "医学", code: "10", spe_id: "12"}
-    10: {name: "管理学", code: "12", spe_id: "13"}
-    11: {name: "艺术学", code: "13", spe_id: "14"}
-'''
+    :param i: (int) 当前进度。
+    :param df: (DataFrame) 抓取的数据。
+    """
+    with open('./progress.txt', 'w') as f:
+        f.write(f'{i}')
+    df.to_csv('./output/result.csv', index=False)
+
+
+# 获取当前进度和已抓取的数据
+i, df = get_progress()
+
+# 获取学校列表
+lst_sch = get_school_list(province_id="33")[i:]
+
+try:
+    # 遍历学校列表
+    for sid, scode, sname, province, city in lst_sch:
+        school_details = []
+        # 获取2023年至2019年的详细信息
+        for year in range(2023, 2019, -1):
+            details = get_detail(year=year, school_id=sid)
+            for item in details:
+                school_details.append(
+                    [year, province, scode[:-2], sname, item['spname'],
+                     item['min'], item['min_section'], item['sp_info'], city,
+                     item['local_batch_name'], f'https://www.gaokao.cn/school/{sid}/provinceline'])
+        # 将详细信息添加到DataFrame
+        df = df.append(pd.DataFrame(school_details, columns=df.columns))
+        # 增加进度
+        i += 1
+finally:
+    # 保存进度和抓取的数据
+    save_progress(i, df)


### PR DESCRIPTION
主要更新了API地址，不过因为API的变动，获取到的数据中不再含有`学科门类`，`专业类`两项，因此删除了这两项。

用了pandas来替代了csv，修改了部分代码逻辑，增加了部分注释。

还有就是通过`get_progress`和`save_progress`函数，使得在触发网站反爬机制后，先保存已经获取完的部分，同时下一次从还未获取的部分开始。